### PR TITLE
Fix TF32 warning with pyannote

### DIFF
--- a/whisperx/diarize.py
+++ b/whisperx/diarize.py
@@ -20,6 +20,14 @@ class DiarizationPipeline:
         model_config = model_name or "pyannote/speaker-diarization-3.1"
         self.model = Pipeline.from_pretrained(model_config, use_auth_token=use_auth_token).to(device)
 
+        # Re-enable TF32 after pyannote modified it
+        try:
+            from whisperx.utils import enable_tf32
+
+            enable_tf32()
+        except Exception:
+            pass
+
     def __call__(
         self,
         audio: Union[str, np.ndarray],

--- a/whisperx/utils.py
+++ b/whisperx/utils.py
@@ -5,6 +5,8 @@ import sys
 import zlib
 from typing import Callable, Optional, TextIO
 
+import torch
+
 LANGUAGES = {
     "en": "english",
     "zh": "chinese",
@@ -440,3 +442,16 @@ def interpolate_nans(x, method='nearest'):
         return x.interpolate(method=method).ffill().bfill()
     else:
         return x.ffill().bfill()
+
+
+def enable_tf32():
+    """Re-enable TF32 on CUDA devices if available.
+
+    Pyannote disables TF32 to ensure reproducibility which might reduce
+    WhisperX performance. This helper restores TF32 settings after loading
+    pyannote models.
+    """
+
+    if torch.cuda.is_available():
+        torch.backends.cuda.matmul.allow_tf32 = True
+        torch.backends.cudnn.allow_tf32 = True

--- a/whisperx/vads/pyannote.py
+++ b/whisperx/vads/pyannote.py
@@ -45,6 +45,14 @@ def load_vad_model(device, vad_onset=0.500, vad_offset=0.363, use_auth_token=Non
     vad_pipeline = VoiceActivitySegmentation(segmentation=vad_model, device=torch.device(device))
     vad_pipeline.instantiate(hyperparameters)
 
+    # Re-enable TF32 after pyannote modified it
+    try:
+        from whisperx.utils import enable_tf32
+
+        enable_tf32()
+    except Exception:
+        pass
+
     return vad_pipeline
 
 class Binarize:


### PR DESCRIPTION
## Summary
- re-enable TF32 after loading pyannote models
- add utility helper to handle TF32

## Testing
- `python -m py_compile whisperx/utils.py whisperx/vads/pyannote.py whisperx/diarize.py`
- `python -m whisperx --help` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_685ac9fc1ef883218fb5b080b91f7823