### PR TITLE
Suppress pyannote reproducibility warning

### DIFF
--- a/whisperx/diarize.py
+++ b/whisperx/diarize.py
@@ -6,6 +6,7 @@ import torch
 
 from whisperx.audio import load_audio, SAMPLE_RATE
 from whisperx.types import TranscriptionResult, AlignedTranscriptionResult
+from whisperx.utils import suppress_reproducibility_warnings
 
 
 class DiarizationPipeline:
@@ -17,6 +18,8 @@ class DiarizationPipeline:
     ):
         if isinstance(device, str):
             device = torch.device(device)
+
+        suppress_reproducibility_warnings()
         model_config = model_name or "pyannote/speaker-diarization-3.1"
         self.model = Pipeline.from_pretrained(model_config, use_auth_token=use_auth_token).to(device)
 

--- a/whisperx/utils.py
+++ b/whisperx/utils.py
@@ -455,3 +455,14 @@ def enable_tf32():
     if torch.cuda.is_available():
         torch.backends.cuda.matmul.allow_tf32 = True
         torch.backends.cudnn.allow_tf32 = True
+
+
+def suppress_reproducibility_warnings():
+    """Suppress pyannote's reproducibility warnings about TF32."""
+    try:
+        from pyannote.audio.utils.reproducibility import ReproducibilityWarning
+        import warnings
+
+        warnings.filterwarnings("ignore", category=ReproducibilityWarning)
+    except Exception:
+        pass

--- a/whisperx/vads/pyannote.py
+++ b/whisperx/vads/pyannote.py
@@ -13,6 +13,7 @@ from pyannote.core import Segment
 
 from whisperx.diarize import Segment as SegmentX
 from whisperx.vads.vad import Vad
+from whisperx.utils import suppress_reproducibility_warnings
 
 
 def load_vad_model(device, vad_onset=0.500, vad_offset=0.363, use_auth_token=None, model_fp=None):
@@ -37,6 +38,7 @@ def load_vad_model(device, vad_onset=0.500, vad_offset=0.363, use_auth_token=Non
 
     model_bytes = open(model_fp, "rb").read()
 
+    suppress_reproducibility_warnings()
     vad_model = Model.from_pretrained(model_fp, use_auth_token=use_auth_token)
     hyperparameters = {"onset": vad_onset,
                     "offset": vad_offset,


### PR DESCRIPTION
## Summary
- add utility to suppress pyannote reproducibility warnings about TF32
- ignore that warning when instantiating diarization and VAD models

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_685b06ade8d88321a5fd42e2a94d1c7e